### PR TITLE
Check power state prior to issuing power command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye
+FROM python:3.11-slim-bullseye
 
 WORKDIR /app
 
@@ -15,5 +15,6 @@ ENV UC_INTEGRATION_INTERFACE="0.0.0.0"
 ENV UC_INTEGRATION_HTTP_PORT="9090"
 
 ENV UC_CONFIG_HOME="/config"
+LABEL org.opencontainers.image.source https://github.com/jackjpowell/uc-intg-jvc
 
 CMD ["python3", "-u", "intg-jvc/driver.py"]

--- a/driver.json
+++ b/driver.json
@@ -1,6 +1,6 @@
 {
 	"driver_id": "jvc_projector_driver",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"min_core_api": "0.20.0",
 	"name": { "en": "JVC Projector" },
 	"icon": "uc:projector",
@@ -41,5 +41,5 @@
 		}
       ]
 	},
-	"release_date": "2024-12-16"
+	"release_date": "2024-12-24"
 }

--- a/intg-jvc/projector.py
+++ b/intg-jvc/projector.py
@@ -58,7 +58,11 @@ class Projector:
         match cmd_name:
             case ucapi.media_player.Commands.ON:
                 try:
-                    self._client.power_on()
+                    _LOG.debug("Prior to sending Power on command the assumed state is: %s", driver.api.configured_entities.get("state",""))
+                    if not self._client.is_on:
+                        _LOG.debug("The projector reported the state as off. Powering on.")
+                        self._client.power_on()
+                        _LOG.debug("Follow up debug statement after command power on send.")
                     driver.api.configured_entities.update_attributes(
                         entity_id,
                         {
@@ -70,7 +74,11 @@ class Projector:
 
             case ucapi.media_player.Commands.OFF:
                 try:
-                    self._client.power_off()
+                    _LOG.debug("Prior to sending Power off command the assumed state is: %s", driver.api.configured_entities.get("state",""))
+                    if self._client.is_on:
+                        _LOG.debug("The projector reported the state as on. Powering off.")
+                        self._client.power_off()
+                        _LOG.debug("Follow up debug statement after command power off send.")
                     driver.api.configured_entities.update_attributes(
                         entity_id,
                         {
@@ -82,7 +90,8 @@ class Projector:
 
             case ucapi.media_player.Commands.TOGGLE:
                 try:
-                    if self._client.power_state() in ["lamp_on"]:
+                    _LOG.debug("Toggling Power requested.")
+                    if self._client.is_on:
                         self._client.power_off()
                         driver.api.configured_entities.update_attributes(
                             entity_id,


### PR DESCRIPTION
This change checks the current power state prior to issuing a power on/off command. If the projector is already in the correct state, skip issuing the command and report success. 